### PR TITLE
Release/v0.6.2

### DIFF
--- a/mbf_abstract_nav/cfg/MoveBaseFlex.cfg
+++ b/mbf_abstract_nav/cfg/MoveBaseFlex.cfg
@@ -9,5 +9,5 @@ gen = ParameterGenerator()
 
 add_mbf_abstract_nav_params(gen)
 
-gen.add("restore_defaults", bool_t, 0, "Restore to the original configuration", False)
+gen.add("restore_defaults", bool_t, 0, "Restore to the original configuration.", False)
 exit(gen.generate(PACKAGE, "move_base_flex_node", "MoveBaseFlex"))

--- a/mbf_abstract_nav/src/mbf_abstract_nav/__init__.py
+++ b/mbf_abstract_nav/src/mbf_abstract_nav/__init__.py
@@ -35,7 +35,7 @@ def add_mbf_abstract_nav_params(gen):
             "How much time we allow recovery behaviors to complete before canceling (or stopping if cancel fails) them", 15.0, 0, 100)
 
     gen.add("oscillation_timeout", double_t, 0,
-            "How long in seconds to allow for oscillation before executing recovery behaviors", 0.0, 0, 60)
+            "How long in seconds to allow for oscillation before executing recovery behaviors", 0.0, 0, 900)
     gen.add("oscillation_distance", double_t, 0,
             "How far in meters the robot must move to be considered not to be oscillating", 0.5, 0, 10)
     gen.add("oscillation_angle", double_t, 0,

--- a/mbf_costmap_nav/cfg/MoveBaseFlex.cfg
+++ b/mbf_costmap_nav/cfg/MoveBaseFlex.cfg
@@ -16,6 +16,6 @@ gen.add("shutdown_costmaps", bool_t, 0,
 gen.add("shutdown_costmaps_delay", double_t, 0,
         "How long in seconds to wait after last action before shutting down the costmaps", 1.0, 0, 60)
 
-gen.add("restore_defaults", bool_t, 0, "Restore to the original configuration", False)
+gen.add("restore_defaults", bool_t, 0, "Restore to the original configuration.", False)
 
 exit(gen.generate(PACKAGE, "mbf_costmap_nav", "MoveBaseFlex"))


### PR DESCRIPTION
This pull request makes minor improvements to parameter configuration in the Move Base Flex packages. The main changes include extending the allowed range for the oscillation timeout parameter and standardizing parameter descriptions.

Parameter range adjustment:

* Increased the maximum value for the `oscillation_timeout` parameter from 60 to 900 seconds in `mbf_abstract_nav/src/mbf_abstract_nav/__init__.py`, allowing for longer oscillation detection windows.

Documentation consistency:

* Updated the description for the `restore_defaults` parameter to add a period at the end in both `mbf_abstract_nav/cfg/MoveBaseFlex.cfg` and `mbf_costmap_nav/cfg/MoveBaseFlex.cfg` for consistency. [[1]](diffhunk://#diff-b9cd4bd841fdeb10152ef1958a8898982360325b84dae8b2ea1507fac3489e01L12-R12) [[2]](diffhunk://#diff-e49e7fe1d7788df330b600f615019dc2882a8bd7bbcc852883799a234a1be588L19-R19)